### PR TITLE
Fixes the following error: ERROR. input file "cfg/virtio.scc" does no…

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bbappend
@@ -7,8 +7,11 @@ SRCREV_kmeta = ""
 
 SRCREV = "113831b7f514f64ba5eb3ba5407b1587b36d9d54"
 
+KMETA = "kernel-meta"
+
 SRC_URI = "\
     git://github.com/raspberrypi/linux.git;branch=${LINUX_RPI_BRANCH} \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.4;destsuffix=${KMETA} \
     file://ikconfig.cfg \
 "
 


### PR DESCRIPTION

Fixes the following error: ERROR. input file "cfg/virtio.scc" does not exist when virtualization (i.e. docker) enabled.
Tested on dunfell branch ... not sure if needed on other branches.

To test just add:
DISTRO_FEATURES_append = " systemd virtualization"
to your local.conf
see [fix](https://github.com/agherzan/meta-raspberrypi/pull/738/commits/5255430f20c65b107441b4230d9d8bc377815f00)